### PR TITLE
Log appender buffering

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "bollard",
  "dotenvy",
  "env_logger",
+ "itertools 0.13.0",
  "log",
  "openssl",
  "pacman-repo-utils",
@@ -1684,6 +1685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,7 +2123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39b0deead1528fd0e5947a8546a9642a9777c25f6e1e26f34c97b204bbb465bd"
 dependencies = [
  "heck 0.4.1",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -26,6 +26,7 @@ bigdecimal = "0.4.5"
 env_logger = "0.11.5"
 log = "0.4.22"
 backon = "1.2.0"
+itertools = "0.13.0"
 pacman-repo-utils = {path = "./src/pacman-repo-utils"}
 
 [target.aarch64-unknown-linux-gnu.dependencies]

--- a/backend/src/api/build.rs
+++ b/backend/src/api/build.rs
@@ -1,6 +1,7 @@
 use crate::db::migration::{JoinType, Order};
 use crate::db::prelude::Builds;
 use crate::db::{builds, packages};
+use itertools::Itertools;
 use rocket::response::status::NotFound;
 use rocket::serde::json::Json;
 use rocket::{delete, get, post, State};
@@ -39,23 +40,7 @@ pub async fn build_output(
         Some(v) => match startline {
             None => Ok(v),
             Some(startline) => {
-                let output: Vec<String> = v.split('\n').map(|x| x.to_string()).collect();
-                let len = output.len();
-                let len_missing = len as i32 - startline;
-
-                let output = output
-                    .iter()
-                    .rev()
-                    .take(if len_missing > 0 {
-                        len_missing as usize
-                    } else {
-                        0
-                    })
-                    .rev()
-                    .cloned()
-                    .collect::<Vec<_>>();
-
-                let output = output.join("\n");
+                let output = v.lines().skip(startline as usize).join("\n");
                 Ok(output)
             }
         },

--- a/backend/src/builder/build.rs
+++ b/backend/src/builder/build.rs
@@ -5,7 +5,7 @@ use crate::db::migration::JoinType;
 use crate::db::prelude::{Files, PackagesFiles};
 use crate::db::{builds, files, packages, packages_files};
 use crate::repo::utils::try_remove_archive_file;
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use bollard::container::{
     AttachContainerOptions, Config, CreateContainerOptions, KillContainerOptions, LogOutput,
     WaitContainerOptions,
@@ -51,9 +51,7 @@ pub(crate) async fn prepare_build(
 
     #[cfg(target_arch = "aarch64")]
     if target_platform != "linux/arm64" {
-        return Err(anyhow!(
-            "Unsupported host architecture aarch64 for cross-compile"
-        ));
+        bail!("Unsupported host architecture aarch64 for cross-compile");
     }
 
     Ok((package_model, build_model, target_platform))
@@ -144,7 +142,7 @@ pub async fn build(
                         build_model.id, package_model.name, exit_code
                     ))
                     .await?;
-                return Err(anyhow!("Build failed with exit code: {}", exit_code));
+                bail!("Build failed with exit code: {}", exit_code);
             }
         }
         // timeout branch
@@ -389,7 +387,7 @@ async fn move_and_add_pkgs(
 ) -> anyhow::Result<()> {
     let archive_paths = fs::read_dir(host_build_path.clone())?.collect::<Vec<_>>();
     if archive_paths.is_empty() {
-        return Err(anyhow!("No files found in build directory"));
+       bail!("No files found in build directory");
     }
 
     // remove old files from repo and from direcotry

--- a/backend/src/builder/build.rs
+++ b/backend/src/builder/build.rs
@@ -387,7 +387,7 @@ async fn move_and_add_pkgs(
 ) -> anyhow::Result<()> {
     let archive_paths = fs::read_dir(host_build_path.clone())?.collect::<Vec<_>>();
     if archive_paths.is_empty() {
-       bail!("No files found in build directory");
+        bail!("No files found in build directory");
     }
 
     // remove old files from repo and from direcotry

--- a/backend/src/builder/build.rs
+++ b/backend/src/builder/build.rs
@@ -402,7 +402,7 @@ async fn move_and_add_pkgs(
 
     build_logger
         .append(format!(
-            "Copy {} files from build dir to repo\nDeleting {} old files",
+            "Copy {} files from build dir to repo\nDeleting {} old files\n",
             archive_paths.len(),
             old_files.len()
         ))

--- a/backend/src/builder/logger.rs
+++ b/backend/src/builder/logger.rs
@@ -36,8 +36,7 @@ impl BuildLogger {
             loop {
                 interval.tick().await;
                 notifier_clone.notified().await; // Wait for a notification or timer
-                if let Err(e) = Self::flush_buffer(&db_clone, build_id, &buffer_clone)
-                    .await {
+                if let Err(e) = Self::flush_buffer(&db_clone, build_id, &buffer_clone).await {
                     error!("Failed to flush log buffer for build #{}: {}", build_id, e);
                 }
             }
@@ -100,8 +99,6 @@ impl Drop for BuildLogger {
         let buffer = Arc::clone(&self.buffer);
         let build_id = self.build_id;
 
-        tokio::spawn(async move {
-            Self::flush_buffer(&db, build_id, &buffer).await
-        });
+        tokio::spawn(async move { Self::flush_buffer(&db, build_id, &buffer).await });
     }
 }

--- a/backend/src/builder/logger.rs
+++ b/backend/src/builder/logger.rs
@@ -31,7 +31,7 @@ impl BuildLogger {
         let build_id = logger.build_id;
 
         tokio::spawn(async move {
-            let mut interval = time::interval(Duration::from_secs(2));
+            let mut interval = time::interval(Duration::from_millis(1500));
             loop {
                 notifier_clone.notified().await;
                 interval.tick().await;

--- a/backend/src/builder/logger.rs
+++ b/backend/src/builder/logger.rs
@@ -1,46 +1,107 @@
 use crate::db::builds;
 use crate::db::prelude::Builds;
 use anyhow::anyhow;
-use log::debug;
+use log::{debug, error};
 use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set, TransactionTrait};
-use std::ops::Add;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
+use tokio::time;
 
 #[derive(Debug, Clone)]
 pub struct BuildLogger {
     build_id: i32,
     db: DatabaseConnection,
+    buffer: Arc<Mutex<Vec<String>>>,
+    notifier: Arc<Notify>,
 }
 
 impl BuildLogger {
     pub fn new(build_id: i32, db: DatabaseConnection) -> Self {
-        Self { build_id, db }
+        let logger = Self {
+            build_id,
+            db,
+            buffer: Arc::new(Mutex::new(Vec::new())),
+            notifier: Arc::new(Notify::new()),
+        };
+
+        // Start a background task for flushing
+        let buffer_clone = Arc::clone(&logger.buffer);
+        let notifier_clone = Arc::clone(&logger.notifier);
+        let db_clone = logger.db.clone();
+        let build_id = logger.build_id;
+
+        tokio::spawn(async move {
+            let mut interval = time::interval(Duration::from_secs(2));
+            loop {
+                interval.tick().await;
+                notifier_clone.notified().await; // Wait for a notification or timer
+                if let Err(e) = Self::flush_buffer(&db_clone, build_id, &buffer_clone)
+                    .await {
+                    error!("Failed to flush log buffer for build #{}: {}", build_id, e);
+                }
+            }
+        });
+
+        logger
     }
 
-    pub async fn append(&self, mut text: String) -> anyhow::Result<()> {
-        let txn = self.db.begin().await?;
-        let mut build: builds::ActiveModel = Builds::find_by_id(self.build_id)
+    pub async fn append(&self, text: String) -> anyhow::Result<()> {
+        debug!("{}", text);
+
+        // Add the text to the buffer
+        let mut buffer = self.buffer.lock().await;
+        buffer.push(text);
+        self.notifier.notify_one(); // Notify the background task
+        Ok(())
+    }
+
+    async fn flush_buffer(
+        db: &DatabaseConnection,
+        build_id: i32,
+        buffer: &Arc<Mutex<Vec<String>>>,
+    ) -> anyhow::Result<()> {
+        let mut buffer = buffer.lock().await;
+        if buffer.is_empty() {
+            return Ok(()); // Nothing to flush
+        }
+
+        let combined_text = buffer.join("");
+        buffer.clear(); // Clear the buffer
+
+        let txn = db.begin().await?;
+        let mut build: builds::ActiveModel = Builds::find_by_id(build_id)
             .one(&txn)
             .await?
             .ok_or(anyhow!("build not found"))?
             .into();
 
-        if !text.ends_with('\n') {
-            text = text.add("\n");
-        }
-
-        debug!("{}", text);
-
         match build.output.unwrap() {
             None => {
-                build.output = Set(Some(text));
+                build.output = Set(Some(combined_text));
             }
             Some(s) => {
-                build.output = Set(Some(format!("{s}{text}")));
+                build.output = Set(Some(format!("{s}{combined_text}")));
             }
         }
 
         build.update(&txn).await?;
         txn.commit().await?;
+        debug!("Log buffer flushed!");
         Ok(())
+    }
+}
+
+impl Drop for BuildLogger {
+    fn drop(&mut self) {
+        // force a flush when object is destroyed
+
+        let db = self.db.clone();
+        let buffer = Arc::clone(&self.buffer);
+        let build_id = self.build_id;
+
+        tokio::spawn(async move {
+            Self::flush_buffer(&db, build_id, &buffer).await
+        });
     }
 }

--- a/backend/src/package/add.rs
+++ b/backend/src/package/add.rs
@@ -3,7 +3,7 @@ use crate::builder::types::{Action, BuildStates};
 use crate::db::prelude::Packages;
 use crate::db::{builds, packages};
 use crate::repo::platforms::PLATFORMS;
-use anyhow::anyhow;
+use anyhow::bail;
 use sea_orm::ColumnTrait;
 use sea_orm::QueryFilter;
 use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set, TransactionTrait};
@@ -42,7 +42,7 @@ pub async fn package_add(
         .await?
         .is_some()
     {
-        return Err(anyhow!("Package already exists"));
+        bail!("Package already exists");
     }
 
     let pkg = get_info_by_name(pkg_name).await?;
@@ -98,7 +98,7 @@ pub async fn package_add(
 fn check_platforms(platforms: &Vec<String>) -> anyhow::Result<()> {
     for platform in platforms {
         if !PLATFORMS.contains(&platform.as_str()) {
-            return Err(anyhow!("Invalid platform: {}", platform));
+            bail!("Invalid platform: {}", platform);
         }
     }
     Ok(())

--- a/backend/src/package/update.rs
+++ b/backend/src/package/update.rs
@@ -2,7 +2,7 @@ use crate::aur::api::get_info_by_name;
 use crate::builder::types::{Action, BuildStates};
 use crate::db::prelude::Packages;
 use crate::db::{builds, packages};
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use sea_orm::{ActiveModelTrait, DatabaseConnection, EntityTrait, Set, TransactionTrait};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast::Sender;
@@ -27,7 +27,7 @@ pub async fn package_update(
         .map_err(|_| anyhow!("couldn't download package metadata".to_string()))?;
 
     if !force && pkg_model.version == Some(pkg.version.clone()) {
-        return Err(anyhow!("Package is already up to date"));
+        bail!("Package is already up to date");
     }
 
     pkg_model_active.status = Set(BuildStates::ENQUEUED_BUILD);

--- a/backend/src/pacman-repo-utils/src/pkginfo/parser.rs
+++ b/backend/src/pacman-repo-utils/src/pkginfo/parser.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::bail;
 use base64::engine::general_purpose;
 use base64::Engine;
 use std::io::{BufRead, Read};
@@ -98,12 +98,12 @@ impl Pkginfo {
             let sigdata = fs::read(&sigfile)?;
             if sigdata.starts_with(b"-----BEGIN PGP SIGNATURE-----") {
                 eprintln!("Cannot use armored signatures for packages: {}", sigfile);
-                return Err(anyhow!("Invalid package signature file"));
+                bail!("Invalid package signature file");
             }
             let pgpsigsize = sigdata.len();
             if pgpsigsize > 16384 {
                 eprintln!("Invalid package signature file '{}'.", sigfile);
-                return Err(anyhow!("Invalid package signature file"));
+                bail!("Invalid package signature file");
             }
 
             self.pgpsig = general_purpose::STANDARD.encode(&sigdata);

--- a/backend/src/pacman-repo-utils/src/repo_add.rs
+++ b/backend/src/pacman-repo-utils/src/repo_add.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 
 use crate::pkginfo::parser::Pkginfo;
 use crate::repo_database::db::add_to_db_file;
@@ -35,7 +35,7 @@ pub fn repo_add_impl(
             Box::new(decoder)
         }
         _ => {
-            return Err(anyhow!("Unsupported file type"));
+            bail!("Unsupported file type");
         }
     };
     let mut archive = Archive::new(decompressor);
@@ -61,7 +61,7 @@ pub fn repo_add_impl(
 
     if !pkginfo.valid() {
         error!("Invalid package file '{}'.", pkgfile);
-        return Err(anyhow!("Invalid package file"));
+        bail!("Invalid package file");
     }
 
     // Compute base64'd PGP signature

--- a/backend/src/pacman-repo-utils/src/repo_init.rs
+++ b/backend/src/pacman-repo-utils/src/repo_init.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use flate2::read::GzEncoder;
 use flate2::Compression;
 use log::info;
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 pub fn init_repo_impl(path: &PathBuf, name: &str) -> anyhow::Result<()> {
     if repo_exists(path, name).is_ok() {
-        info!("Pacman repo archive already exists");
+        info!("Pacman repo '{}' archive already exists at path '{}'", name, path.display());
         return Ok(());
     }
 
@@ -28,7 +28,7 @@ fn repo_exists(path: &PathBuf, name: &str) -> anyhow::Result<()> {
         let files = get_archive_names(name, suffix);
         for file in [files.0, files.1] {
             if fs::metadata(&path.join(&file)).is_err() {
-                return Err(anyhow!("{} doesn't exist", file));
+                bail!("{} doesn't exist", file);
             }
         }
     }

--- a/frontend/lib/api/packages.dart
+++ b/frontend/lib/api/packages.dart
@@ -56,8 +56,9 @@ extension PackagesAPI on ApiClient {
     final resp = await getRawClient()
         .post("/package/$id/update", data: {'force': force});
     print(resp.data);
-
-    return resp.data as List<int>;
+    final List<int> ids =
+        (resp.data as List).map((e) => e as int).toList(growable: false);
+    return ids;
   }
 
   Future<bool> deletePackage(int id) async {

--- a/frontend/lib/components/build_output.dart
+++ b/frontend/lib/components/build_output.dart
@@ -66,16 +66,19 @@ class _BuildOutputState extends State<BuildOutput> {
     // poll new output only if not finished
     if (widget.build.status == 0) {
       outputTimer = Timer.periodic(const Duration(seconds: 3), (Timer t) async {
+        print("refreshing output");
+        final value = await API.getOutput(
+            buildID: widget.build.id, line: output.split("\n").length);
+        if (value.isNotEmpty) {
+          setState(() {
+            output += "\n$value";
+          });
+        }
+
         final follow =
             Provider.of<BuildLogProvider>(context, listen: false).followLog;
-        if (follow) {
-          print("refreshing output");
-          final value = await API.getOutput(
-              buildID: widget.build.id, line: output.split("\n").length);
-          setState(() {
-            output += value;
-          });
 
+        if (follow) {
           Provider.of<BuildLogProvider>(context, listen: false).go_to_bottom();
         }
       });

--- a/frontend/lib/screens/package_screen.dart
+++ b/frontend/lib/screens/package_screen.dart
@@ -106,15 +106,10 @@ class _PackageScreenState extends State<PackageScreen> {
               "Are you sure to force an Package rebuild?",
               () async {
                 await API.updatePackage(force: true, id: pkg.id);
-
-                context.pop();
-
-                Provider.of<PackagesProvider>(context, listen: false)
-                    .refresh(context);
-                Provider.of<BuildsProvider>(context, listen: false)
-                    .refresh(context);
-                Provider.of<StatsProvider>(context, listen: false)
-                    .refresh(context);
+                if (mounted) {
+                  Provider.of<BuildsProvider>(context, listen: false)
+                      .refresh(context);
+                }
               },
               () {},
             );


### PR DESCRIPTION
Avoid thousands of db writes during a package build by buffering log appends and flushing buffer every some seconds.

* implement Log appender buffering to avoid too many db calls when multiple active builds running

* use bail macro instead of return Err(anyhow...

Todo:

- [ ] configure flush timeout with env variable