### PR TITLE
Do not request user:email scope

### DIFF
--- a/backend/aurcache/src/api/auth.rs
+++ b/backend/aurcache/src/api/auth.rs
@@ -28,7 +28,7 @@ pub struct OauthUserInfo {
 #[get("/login")]
 pub fn oauth_login(oauth2: OAuth2<OauthUserInfo>, cookies: &CookieJar<'_>) -> Redirect {
     oauth2
-        .get_redirect(cookies, &["user:email", "profile", "openid", "email"])
+        .get_redirect(cookies, &["profile", "openid", "email"])
         .unwrap()
 }
 


### PR DESCRIPTION
The user:email scope is authentik exclusive. It also shouldn't be required if `email` is already requested? (Not 100% sure about that.)

Mostly it prevents working with Google account oauth, as Google does not recognize this scope and returns an error if attempting to connect.

Fixes #209 

This is the simple/dumb fix. A more complex approach (that could come later) could be to have a configurable set of scopes to request.