### PR TITLE
Use login shell to build packages

### DIFF
--- a/backend/aurcache/src/builder/docker.rs
+++ b/backend/aurcache/src/builder/docker.rs
@@ -197,7 +197,12 @@ impl Builder {
             attach_stderr: Some(true),
             open_stdin: Some(false),
             user: Some("ab".to_string()),
-            cmd: Some(vec!["sh".to_string(), "-c".to_string(), cmd]),
+            cmd: Some(vec![
+                "sh".to_string(),
+                "-l".to_string(),
+                "-c".to_string(),
+                cmd,
+            ]),
             host_config: Some(HostConfig {
                 #[cfg(debug_assertions)]
                 auto_remove: Some(false),


### PR DESCRIPTION
By default `sh` (or `bash`) in docker will run as non-login shell. Among other things, this means it will not read `/etc/profile`, which sets many PATH values.

To see the difference (yes, perl looks like the only offender here):
```
~> docker run --rm ghcr.io/lukas-heiligenbrunner/aurcache-builder:latest sh -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
~> docker run --rm ghcr.io/lukas-heiligenbrunner/aurcache-builder:latest sh -lc 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl
```

For a concrete example, the current build scripts will not have `/usr/bin/core_perl` in the `PATH`, which is required for `pod2man`, used by the `zpaq` package.

With `-l`, the shell is asked to force a "login shell" mode, sourcing this file and having all expected paths available.