### PR TITLE
fix mirrorlist fetch error

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2232,6 +2232,7 @@ name = "pacman-mirrors"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "backon",
  "chrono",
  "log",
  "reqwest 0.12.22",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,6 +11,7 @@ reqwest = "0.12.22"
 log = "0.4.27"
 chrono = "0.4.41"
 serde = "1.0.219"
+backon = "1.5.2"
 
 [profile.release]
 strip = "debuginfo"  # Automatically strip symbols from the binary.

--- a/backend/aurcache/Cargo.toml
+++ b/backend/aurcache/Cargo.toml
@@ -30,7 +30,7 @@ bollard = "0.19.2"
 bigdecimal = "0.4.8"
 env_logger = "0.11.8"
 log = {workspace = true}
-backon = "1.5.2"
+backon = {workspace = true}
 itertools = "0.14.0"
 cron = "0.15.0"
 serde_json = "1.0.142"

--- a/backend/pacman-mirrors/Cargo.toml
+++ b/backend/pacman-mirrors/Cargo.toml
@@ -8,5 +8,6 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true, features = ["derive"] }
 anyhow = {workspace = true}
 log = {workspace = true}
+backon = {workspace = true}
 
 url = { version = "2.5.4", features = ["serde"] }


### PR DESCRIPTION
Mirrorlist fetching fails again because 
https://archlinux.org/mirrors/status/json expects http1 requests and user_agent