### PR TITLE
update pkg db before build and trustdb init

### DIFF
--- a/backend/aurcache/src/builder/docker.rs
+++ b/backend/aurcache/src/builder/docker.rs
@@ -184,7 +184,7 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
 
         let build_cmd = format!("paru {build_flags} {name}");
         // first update the package list, then update trustdb and then build cmd
-        let steps = vec![
+        let steps = [
             "sudo pacman -Sy --noconfirm",
             "sudo pacman-key --init",
             "sudo pacman-key --populate archlinux",


### PR DESCRIPTION
When a package is not longer than >7 days on AUR the package cache is too old (from the weekly rebuild) and it doesn't find the package to build. (although 'paru -Syu ..' build command should refresh it, but somehow it doesn't)

fix #255