### PR TITLE
auto rm build containers on exit

### DIFF
--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -254,7 +254,7 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
                 #[cfg(debug_assertions)]
                 auto_remove: Some(false),
                 #[cfg(not(debug_assertions))]
-                auto_remove: Some(false),
+                auto_remove: Some(true),
                 nano_cpus: Some(cpu_limit as i64),
                 memory_swap: Some(memory_limit),
                 binds: Some(mountpoints),


### PR DESCRIPTION
Build containers aren't removed after builds.
Somehow this slipped into prod, sorry for that.