### PR TITLE
fix invalid build cache paths which got messed up by refactor

### DIFF
--- a/backend/aurcache-builder/src/build_mode.rs
+++ b/backend/aurcache-builder/src/build_mode.rs
@@ -12,13 +12,16 @@ pub struct HostBuildconfig {
     pub mirrorlist_path_host: String,
     pub mirrorlist_path_aurcache: String,
 
+    /// dir on docker host
     pub build_artifact_dir_host: String,
+    /// dir inside aurcache
+    pub build_artifact_dir_aurcache: String,
 }
 
 pub struct DinDBuildconfig {
     pub mirrorlist_path: String,
     /// package build path in aurcache container
-    pub aurcache_build_path: String,
+    pub build_path: String,
 }
 
 #[must_use]
@@ -27,7 +30,7 @@ pub fn get_build_mode() -> BuildMode {
 
     if let Ok(v) = env::var("BUILD_ARTIFACT_DIR") {
         let mut build_artifact_dir_aurcache = current_dir;
-        build_artifact_dir_aurcache.push("../../builds");
+        build_artifact_dir_aurcache.push("builds");
 
         let build_artifact_dir_host = v.clone();
         let mirrorlist_path_aurcache = format!(
@@ -50,6 +53,7 @@ pub fn get_build_mode() -> BuildMode {
             mirrorlist_path_host,
             mirrorlist_path_aurcache,
             build_artifact_dir_host,
+            build_artifact_dir_aurcache: build_artifact_dir_aurcache.display().to_string(),
         };
         BuildMode::Host(cfg)
     } else {
@@ -69,12 +73,12 @@ pub fn get_build_mode() -> BuildMode {
 
         // in dind mode packages are stored to ./builds/ by default
         let mut aurcache_build_path = current_dir;
-        aurcache_build_path.push("../../builds");
+        aurcache_build_path.push("builds");
         create_config_dir(aurcache_build_path.display().to_string());
 
         let cfg = DinDBuildconfig {
             mirrorlist_path,
-            aurcache_build_path: aurcache_build_path.display().to_string(),
+            build_path: aurcache_build_path.display().to_string(),
         };
         BuildMode::DinD(cfg)
     }

--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -139,7 +139,7 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
         // create new docker container for current build
         let build_dir_base = "/var/cache/makepkg/pkg";
         let host_build_path_docker = match get_build_mode() {
-            BuildMode::DinD(cfg) => cfg.aurcache_build_path,
+            BuildMode::DinD(cfg) => cfg.build_path,
             BuildMode::Host(cfg) => cfg.build_artifact_dir_host,
         };
         let mountpoints = vec![format!("{}:{}", host_build_path_docker, build_dir_base)];

--- a/backend/aurcache-builder/src/path_utils.rs
+++ b/backend/aurcache-builder/src/path_utils.rs
@@ -1,13 +1,24 @@
+use crate::build_mode::{BuildMode, get_build_mode};
+use std::fs;
 use std::fs::Permissions;
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use std::{env, fs};
 
+/// create the build directory of the package to newly build (as path view of aurcache)
 pub fn create_active_build_path(pkg_name: String) -> anyhow::Result<PathBuf> {
-    // this path is hardcoded at /app/builds/<pkgname>
-    let mut path = env::current_dir()?;
-    path.push("../../builds");
-    path.push(pkg_name);
+    let path = match get_build_mode() {
+        BuildMode::DinD(v) => {
+            let mut build_path = PathBuf::from(v.build_path);
+            build_path.push(pkg_name);
+            build_path
+        }
+        BuildMode::Host(v) => {
+            let mut build_path = PathBuf::from(v.build_artifact_dir_aurcache);
+            build_path.push(pkg_name);
+            build_path
+        }
+    };
+
     fs::create_dir_all(path.clone())?;
     fs::set_permissions(path.clone(), Permissions::from_mode(0o777))?;
 


### PR DESCRIPTION
Somehow a refactoring caused `../../` to be added to the build cache path which messes up built file locations in some cases.
(especially host build mode)

This fixes this and improves cration of active build path to use the previously provided structure.


fix #298 