### PR TITLE
Alternative Archlinux Mirrorlist URL

### DIFF
--- a/backend/pacman-mirrors/src/status.rs
+++ b/backend/pacman-mirrors/src/status.rs
@@ -58,7 +58,7 @@ impl Status {
                     // fetch original archlinux.org mirrorlist
                     Self::get_from_url(Self::URL_X86_64, target_platform).await
                 })
-                .retry(FibonacciBuilder::default().with_max_times(4))
+                .retry(FibonacciBuilder::default().with_max_times(2))
                 .await;
                 match result {
                     Ok(v) => Ok(v),
@@ -72,7 +72,7 @@ impl Status {
                             // fetch alternative archlinux mirrorlist
                             Self::get_from_url(Self::URL_X86_64_ALT, target_platform).await
                         })
-                        .retry(FibonacciBuilder::default().with_max_times(3))
+                        .retry(FibonacciBuilder::default().with_max_times(4))
                         .await
                     }
                 }


### PR DESCRIPTION
The orginal Archlinux Mirrorlist URL keeps timing out and is down sometimes:
https://archlinux.org/mirrors/status/json

Use alternative mirrorlist url when this happens:
https://arjixwastaken.github.io/arch-mirrorlist-mirror/mirrors.json