### PR TITLE
Maintain a clean build dir

### DIFF
--- a/backend/aurcache-builder/src/build.rs
+++ b/backend/aurcache-builder/src/build.rs
@@ -13,11 +13,24 @@ use futures::StreamExt;
 use sea_orm::{ActiveModelTrait, DatabaseConnection, IntoActiveModel, Set, TransactionTrait};
 use std::collections::HashMap;
 use std::fs;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{debug, info};
+
+struct BuildDirGuard {
+    path: PathBuf,
+    id: i32,
+}
+
+impl Drop for BuildDirGuard {
+    fn drop(&mut self) {
+        info!("Build {}: Remove shared build folder", self.id);
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
 
 pub struct Builder {
     pub(crate) db: DatabaseConnection,
@@ -116,6 +129,12 @@ impl Builder {
             "Build #{}: awaiting build container to exit",
             self.build_model.id.get()?
         );
+        // RAII guard: clean up build dir when Builder is dropped, regardless of success/failure
+        let _guard = BuildDirGuard {
+            path: host_active_build_path.clone(),
+            id: *self.build_model.id.get()?,
+        };
+
         self.wait_container_exit(&id).await?;
         info!("Build #{id}: docker container exited successfully");
 
@@ -126,12 +145,7 @@ impl Builder {
         );
         self.move_and_add_pkgs(host_active_build_path.clone())
             .await?;
-        // remove active build dir
-        info!(
-            "Build {}: Remove shared build folder",
-            self.build_model.id.get()?
-        );
-        fs::remove_dir_all(host_active_build_path)?;
+
         Ok(())
     }
 

--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -142,9 +142,12 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
             BuildMode::DinD(cfg) => cfg.build_path,
             BuildMode::Host(cfg) => cfg.build_artifact_dir_host,
         };
-        let container_build_dir = "/build/src";
-        let container_pkgdest_dir = "/build";
-        let mountpoints = vec![format!("{}/{name}:/build", host_build_dir)];
+        let container_pkgdest_dir = Path::new("/build");
+        let container_build_dir = container_pkgdest_dir.join("src");
+        let mountpoints = vec![format!(
+            "{host_build_dir}/{name}:{builder_root}",
+            builder_root = container_pkgdest_dir.display()
+        )];
 
         let mut mounts = vec![];
 
@@ -186,7 +189,7 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
                             typ: Some(MountTypeEnum::VOLUME),
                             read_only: Some(false),
                             volume_options: Some(MountVolumeOptions {
-                                subpath: Some(format!("{}/mirrorlist", subpath)),
+                                subpath: Some(format!("{subpath}/mirrorlist")),
                                 ..Default::default()
                             }),
                             ..Default::default()
@@ -204,7 +207,8 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
         let build_cmd = match source_data {
             SourceData::Aur { .. } => {
                 format!(
-                    "mkdir -p {container_build_dir} && cd {container_build_dir} && {self_update} && paru -G {name} && paru {build_flags} *"
+                    "mkdir -p {container_build_dir} && cd {container_build_dir} && {self_update} && paru -G {name} && paru {build_flags} *",
+                    container_build_dir = container_build_dir.display(),
                 )
             }
             SourceData::Git { .. } => {

--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -142,8 +142,9 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
             BuildMode::DinD(cfg) => cfg.build_path,
             BuildMode::Host(cfg) => cfg.build_artifact_dir_host,
         };
-        let container_build_dir = "/build";
-        let mountpoints = vec![format!("{}/{name}:{container_build_dir}", host_build_dir)];
+        let container_build_dir = "/build/src";
+        let container_pkgdest_dir = "/build";
+        let mountpoints = vec![format!("{}/{name}:/build", host_build_dir)];
 
         let mut mounts = vec![];
 
@@ -196,14 +197,14 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
             mounts.push(mnt);
         }
 
-        let (makepkg_config, makepkg_config_path) = create_makepkg_config(container_build_dir)?;
+        let (makepkg_config, makepkg_config_path) = create_makepkg_config(container_pkgdest_dir)?;
 
         let self_update = "paru -Syu --noconfirm --noprogressbar --color never";
         let source_data = SourceData::from_str(self.package_model.source_data.get()?)?;
         let build_cmd = match source_data {
             SourceData::Aur { .. } => {
                 format!(
-                    "cd {container_build_dir} && {self_update} && paru -G {name} && paru {build_flags} *"
+                    "mkdir -p {container_build_dir} && cd {container_build_dir} && {self_update} && paru -G {name} && paru {build_flags} *"
                 )
             }
             SourceData::Git { .. } => {

--- a/backend/aurcache-builder/src/makepkg_utils.rs
+++ b/backend/aurcache-builder/src/makepkg_utils.rs
@@ -1,9 +1,12 @@
-pub fn create_makepkg_config(pkgdest_dir_base: &str) -> anyhow::Result<(String, String)> {
+use std::path::Path;
+
+pub fn create_makepkg_config(pkgdest_dir_base: &Path) -> anyhow::Result<(String, String)> {
     let makepkg_config = format!(
         "
 MAKEFLAGS=-j$(nproc)
 PKGDEST={pkgdest_dir_base}
-        "
+",
+        pkgdest_dir_base = pkgdest_dir_base.display()
     );
     let makepkg_config_path = "/var/ab/.config/pacman/makepkg.conf";
     Ok((makepkg_config, makepkg_config_path.to_string()))

--- a/backend/aurcache-builder/src/makepkg_utils.rs
+++ b/backend/aurcache-builder/src/makepkg_utils.rs
@@ -1,8 +1,8 @@
-pub fn create_makepkg_config(build_dir_base: &str) -> anyhow::Result<(String, String)> {
+pub fn create_makepkg_config(pkgdest_dir_base: &str) -> anyhow::Result<(String, String)> {
     let makepkg_config = format!(
         "
 MAKEFLAGS=-j$(nproc)
-PKGDEST={build_dir_base}
+PKGDEST={pkgdest_dir_base}
         "
     );
     let makepkg_config_path = "/var/ab/.config/pacman/makepkg.conf";

--- a/scripts/test-builder.sh
+++ b/scripts/test-builder.sh
@@ -3,7 +3,7 @@ set -e
 
 PACKAGE="${1:-hello}"
 BUILDER_IMAGE="${2:-aurcache-builder:test}"
-BUILD_FLAGS="${3--B --noconfirm --noprogressbar --color never}"
+BUILD_FLAGS="${3--B --noconfirm --noprogressbar --color never --pgpfetch}"
 
 docker build -f docker/builder.Dockerfile -t $BUILDER_IMAGE .
 
@@ -27,7 +27,8 @@ docker run --rm \
     -v "$BUILD_DIR:/build" \
     --user ab \
     "$BUILDER_IMAGE" sh -c "
-        cd /build
+        mkdir -p /build/src
+        cd /build/src
 
         # Write makepkg config (same as aurcache)
         cat > $MAKEPKG_CONF << EOF


### PR DESCRIPTION
This brings two changes:

* Download the package to build in a `src` subdirectory of /build.
* Cleanup the build dir even if a build error occured.
  * I used a RAII guard (similar to defer in golang) to ensure we cleanup the package as the last step of the build function. I think it's fine but it does hide any i/o error when removing the dir. If that's a concern we can, on the success path, consume the guard to properly bubble up any error. Just a bit more boilerplate.

These are intended to fix the situation of files accumulating in the build directory after a build failure, and the presence of these files causing the build to keep failing.

This was caused by:
* The build step uses `pacman -B *` to build whatever was just downloaded, because that folder name can differ from the package name (in the case of split packages). This means we need to be careful not to have extra files. Easier to guarantee if we don't share that folder with PKGDEST, where package files are produced.
* In theory we start building from scratch every time, so there should not be any package file _yet_ in that build dir. But we actually were bailing in case of a build error and were skipping the cleanup part, leaving any package file in the build folder.

We only _need_ to fix one of the two causes to solve the issue, but it's safer to fix both.
