### PR TITLE
Fetch pgp keys as needed

### DIFF
--- a/backend/aurcache-utils/src/package/add.rs
+++ b/backend/aurcache-utils/src/package/add.rs
@@ -58,6 +58,7 @@ pub async fn package_add(
 
             let build_flags = build_flags.unwrap_or_else(|| {
                 vec![
+                    "--pgpfetch".to_string(),
                     "-B".to_string(),
                     "--noconfirm".to_string(),
                     "--noprogressbar".to_string(),
@@ -111,6 +112,7 @@ pub async fn package_add(
 
             let build_flags = build_flags.unwrap_or_else(|| {
                 vec![
+                    "--pgpfetch".to_string(),
                     "-B".to_string(),
                     "--noconfirm".to_string(),
                     "--noprogressbar".to_string(),


### PR DESCRIPTION
This adds `--pgpfetch` as a default argument to paru, to let it download pgp keys listed in pkgbuilds. For example the `asp` or `libjpeg6-turbo` both list pgp keys, and fail to build without this.

An alternative is to disable pgp validation entirely, with the obvious security loss.
