### PR TITLE
fix arm32 builder image builds by cross compiling the binaries on amd64

### DIFF
--- a/docker/add-aur.sh
+++ b/docker/add-aur.sh
@@ -36,7 +36,7 @@ sed -i 's/^#Server/Server/' /etc/pacman.d/mirrorlist.backup
 rankmirrors -n 10 /etc/pacman.d/mirrorlist.backup > /etc/pacman.d/mirrorlist
 rm /etc/pacman.d/mirrorlist.backup
 
-pacman --sync --needed --noconfirm --noprogressbar sudo base-devel git rust || echo "Nothing to do"
+pacman --sync --needed --noconfirm --noprogressbar sudo base-devel git || echo "Nothing to do"
 git config --global --add safe.directory '*'
 
 # create the user
@@ -76,28 +76,16 @@ FPP=$(dirname "${FOREIGN_PKG}")
 mkdir -p "${FPP}"
 install -o "${AUR_USER}" -d "${FOREIGN_PKG}"
 
-# Prepare paru helper.
-# Currently builds from source, from a fork with some fixes.
-# Eventually, we could build from upstream, from crates.io, or even install the paru package itself.
-sudo -u "${AUR_USER}" bash -c "cargo install --git https://github.com/gyscos/paru"
-cp "${AUR_USER_HOME}/.cargo/bin/paru" /usr/local/bin/
-chmod 755 /usr/local/bin/paru
-
 # Remove all pacman caches
 pacman -Scc --noconfirm || echo "Pacman cache already clean"
 
 # Remove orphaned packages (installed as dependencies but no longer needed)
 pacman -Rns --noconfirm $(pacman -Qtdq) || echo "No orphaned packages to remove"
 
-# remove previously installed packages
-pacman -Rns --noconfirm rust || echo "Build dependencies already removed"
-
 # cleanup
 sudo rm -rf "${NEW_PKGDEST}"/*
 rm -rf "${AUR_USER_HOME}/.cache/go-build"
-rm -rf "${AUR_USER_HOME}/.cargo"
 rm -rf /tmp/*
-rm -rf /root/.cargo /usr/share/cargo || true
 rm -rf /var/tmp/* /var/cache/* || true
 
 echo "Cleanup complete"

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -8,6 +8,60 @@ FROM --platform=linux/arm64 lopsided/archlinux:latest AS arch_arm64
 FROM --platform=linux/riscv64 ogarcia/archlinux:latest AS arch_riscv64
 FROM --platform=linux/arm/v7 lopsided/archlinux-arm32v7:latest AS arch_armv7
 
+########## Target sysroot (extract libs for cross-compilation) ##########
+FROM arch_${TARGETARCH}${TARGETVARIANT:+${TARGETVARIANT}} AS target_sysroot
+RUN pacman -Syu --noconfirm gcc
+
+########## Cross-compile paru on amd64 ##########
+FROM --platform=linux/amd64 archlinux/archlinux:latest AS paru_builder
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+RUN pacman -Syu --noconfirm base-devel clang lld rustup
+
+COPY --from=target_sysroot /usr/lib/ /target-sysroot/usr/lib/
+COPY --from=target_sysroot /usr/include/ /target-sysroot/usr/include/
+
+RUN rustup default stable
+RUN rustup target add aarch64-unknown-linux-gnu armv7-unknown-linux-gnueabihf riscv64gc-unknown-linux-gnu
+
+RUN <<'SCRIPT'
+set -eux
+ARCH="${TARGETARCH}${TARGETVARIANT}"
+
+# Map Docker arch to Rust target and clang target triple
+case "$ARCH" in
+  amd64)   RUST_TARGET=x86_64-unknown-linux-gnu;      CLANG_TARGET="" ;;
+  arm64)   RUST_TARGET=aarch64-unknown-linux-gnu;      CLANG_TARGET=aarch64-linux-gnu ;;
+  armv7)   RUST_TARGET=armv7-unknown-linux-gnueabihf;  CLANG_TARGET=armv7-linux-gnueabihf ;;
+  riscv64) RUST_TARGET=riscv64gc-unknown-linux-gnu;    CLANG_TARGET=riscv64-linux-gnu ;;
+  *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+# Set up cross-compilation for non-amd64 targets
+if [ -n "$CLANG_TARGET" ]; then
+  # Find GCC CRT/runtime directory in target sysroot
+  GCC_DIR=$(find /target-sysroot/usr/lib/gcc -name crtbeginS.o -printf '%h\n' 2>/dev/null | head -1 || true)
+  GCC_FLAGS="${GCC_DIR:+-B$GCC_DIR -L$GCC_DIR}"
+
+  # Create clang cross-compiler wrapper
+  printf '#!/bin/sh\nexec clang --target=%s --sysroot=/target-sysroot -fuse-ld=lld %s "$@"\n' "$CLANG_TARGET" "$GCC_FLAGS" \
+    > /usr/local/bin/clang-cross && chmod +x /usr/local/bin/clang-cross
+
+  # Configure cargo, cc, bindgen, and pkg-config for the target
+  TARGET_UPPER=$(echo "$RUST_TARGET" | tr 'a-z-' 'A-Z_')
+  TARGET_UNDER=$(echo "$RUST_TARGET" | tr '-' '_')
+  export "CARGO_TARGET_${TARGET_UPPER}_LINKER=/usr/local/bin/clang-cross"
+  export "CC_${TARGET_UNDER}=/usr/local/bin/clang-cross"
+  export "BINDGEN_EXTRA_CLANG_ARGS_${TARGET_UNDER}=--target=$CLANG_TARGET --sysroot=/target-sysroot"
+  export "PKG_CONFIG_SYSROOT_DIR_${TARGET_UNDER}=/target-sysroot"
+  export "PKG_CONFIG_LIBDIR_${TARGET_UNDER}=/target-sysroot/usr/lib/pkgconfig"
+  export PKG_CONFIG_ALLOW_CROSS=1
+fi
+
+cargo install --features "generate" --git https://github.com/gyscos/paru --target="$RUST_TARGET"
+SCRIPT
+
 ########## Select correct base ##########
 FROM arch_${TARGETARCH}${TARGETVARIANT:+${TARGETVARIANT}} AS final
 
@@ -21,5 +75,6 @@ ENV TARGETPLATFORM=${TARGETPLATFORM}
 ########## Files ##########
 ADD docker/add-aur.sh /root
 ADD docker/pacman.conf.amd64 /etc/pacman.conf.amd64
+COPY --from=paru_builder --chmod=0755 /root/.cargo/bin/paru /usr/local/bin/paru
 RUN /bin/bash /root/add-aur.sh ab paru
 USER ab


### PR DESCRIPTION
On arm32 there occur build issues like the following:

```
#23 415.2 error: failed to clone into: /var/ab/.cargo/git/db/paru-d9fdd419e78013b5
#23 415.2 
#23 415.2 Caused by:
#23 415.2   could not read directory '/var/ab/.cargo/git/db/paru-d9fdd419e78013b5/refs': Value too large for defined data type; class=Os (2)
#23 ERROR: process "/bin/sh -c /bin/bash /root/add-aur.sh ab paru" did not complete successfully: exit code: 101

```

Cross compiling the arm32 binary from amd64 and moving it into the target image should solve the issue