### PR TITLE
Fix git pkg build sudo regression

### DIFF
--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -213,7 +213,7 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
             }
             SourceData::Git { .. } => {
                 format!(
-                    "sudo chmod -R 1777 {GIT_REPO_PATH} && {self_update} && cd {GIT_REPO_PATH} && paru {build_flags} *"
+                    "sudo chmod -R 1777 {GIT_REPO_PATH} && {self_update} && cd {GIT_REPO_PATH} && paru {build_flags} ."
                 )
             }
             SourceData::Upload { .. } => {

--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -213,7 +213,7 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
             }
             SourceData::Git { .. } => {
                 format!(
-                    "chmod -R 1777 {GIT_REPO_PATH} && {self_update} && cd {GIT_REPO_PATH} && paru {build_flags} *"
+                    "sudo chmod -R 1777 {GIT_REPO_PATH} && {self_update} && cd {GIT_REPO_PATH} && paru {build_flags} *"
                 )
             }
             SourceData::Upload { .. } => {


### PR DESCRIPTION
Fix regression caused by #214 

When adding a custom Git repo subdirectory to build the directory is chmodded before build which requires sudo rights:

```
Pulling image: ghcr.io/lukas-heiligenbrunner/aurcache-builder:latestchmod: changing permissions of '/tmp': Operation not permitted
chmod: changing permissions of '/tmp/flutter.sh': Operation not permitted
chmod: changing permissions of '/tmp/no-runtime-download.patch': Operation not permitted
chmod: changing permissions of '/tmp/update-artifact-versions.sh': Operation not permitted
chmod: changing permissions of '/tmp/doctor.patch': Operation not permitted
chmod: changing permissions of '/tmp/gradle-user-home.patch': Operation not permitted
chmod: changing permissions of '/tmp/PKGBUILD': Operation not permitted
chmod: changing permissions of '/tmp/.gitignore': Operation not permitted
chmod: changing permissions of '/tmp/opt-in-analytics.patch': Operation not permitted
chmod: changing permissions of '/tmp/.SRCINFO': Operation not permitted
chmod: changing permissions of '/tmp/version.patch': Operation not permitted
chmod: changing permissions of '/tmp/system-dart.patch': Operation not permitted
chmod: changing permissions of '/tmp/flutter-common.install': Operation not permitted
chmod: changing permissions of '/tmp/no-lock.patch': Operation not permitted
failed to build packageDocker container wait error: 
```

this readds the sudo before the chmod which was deleted in #214