### PR TITLE
Add MIRRORLIST_SERVERS_x86_64 env var as an alternative to mirrorlist mounting

### DIFF
--- a/backend/aurcache/src/main.rs
+++ b/backend/aurcache/src/main.rs
@@ -8,6 +8,7 @@ use aurcache_scheduler::mirror_ranking::start_mirror_rank_job;
 use aurcache_scheduler::update_version_check::start_update_version_checking;
 use aurcache_types::builder::Action;
 use dotenvy::dotenv;
+use std::env;
 use tokio::sync::broadcast;
 use tracing::warn;
 
@@ -30,7 +31,11 @@ async fn main() {
     if let Err(e) = start_auto_update_job(db.clone(), tx.clone()) {
         warn!("auto_update job not properly configured: {e}");
     }
-    if let Err(e) = start_mirror_rank_job(db.clone(), tx.clone()) {
+
+    let mirrorlist_override =
+        env::var("MIRRORLIST_SERVERS_X86_64").is_ok_and(|s| !s.trim().is_empty());
+
+    if !mirrorlist_override && let Err(e) = start_mirror_rank_job(db.clone(), tx.clone()) {
         warn!("mirror_rank job not properly configured: {e}");
     }
     let api_handle = init_api(db, tx);

--- a/backend/aurcache/src/startup.rs
+++ b/backend/aurcache/src/startup.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::path::PathBuf;
 use tokio::fs;
 
@@ -94,13 +95,29 @@ pub async fn post_startup_tasks(db: &DatabaseConnection) -> anyhow::Result<()> {
         BuildMode::Host(cfg) => cfg.mirrorlist_path_aurcache,
     };
 
-    if std::fs::metadata(format!("{mirrorlist_path}/mirrorlist")).is_err() {
+    let mirrorlist_file = format!("{mirrorlist_path}/mirrorlist");
+
+    // Check if mirrorlist servers are provided via env var (semicolon-separated)
+    // Treat an empty var the same way as an unset var.
+    if let Ok(servers) = env::var("MIRRORLIST_SERVERS_X86_64")
+        && !servers.trim().is_empty()
+    {
+        info!("Using mirrorlist from MIRRORLIST_SERVERS_X86_64 env var");
+        let mirrorlist = servers
+            .split(';')
+            .filter(|s| !s.is_empty())
+            .map(|s| format!("Server = {s}\n"))
+            .collect::<Vec<_>>()
+            .join("");
+        fs::write(&mirrorlist_file, mirrorlist).await?;
+        info!("Wrote mirrorlist to {mirrorlist_path}");
+    } else if std::fs::metadata(&mirrorlist_file).is_err() {
         info!("Perform initial load of pacman mirrorlist");
         match pacman_mirrors::get_status(Platform::X86_64).await {
             Ok(status) => {
                 let urls = status.urls;
                 let mirrorlist = urls.gen_mirrorlist(urls.0.clone())?;
-                fs::write(format!("{mirrorlist_path}/mirrorlist"), mirrorlist).await?;
+                fs::write(&mirrorlist_file, mirrorlist).await?;
                 info!("Wrote mirrorlist to {mirrorlist_path}");
             }
             Err(e) => {

--- a/docs/docs/Configuration/mirrorlist.md
+++ b/docs/docs/Configuration/mirrorlist.md
@@ -18,6 +18,24 @@ Only **x86_64** build architecture is supported to set mirrorlist and rerank mir
 |------------------------|--------------|--------------------------------------------------------------------------------|---------------------------|
 | MIRROR_RANK_SCHEDULE                | String(CRON) | Auto mirrorlist rank schedule in cronjob syntax with seconds (null to disable) | 0 0 2 * * 0 (once a week) |
 | MIRRORLIST_PATH_X86_64                | String       | directory containing mirrorlist inside aurcache container                 | /app/config/pacman_x86_64 |
+| MIRRORLIST_SERVERS_X86_64                | String       | semicolon-separated list of mirror URLs (disables auto ranking)                 | null |
+
+## Manually set mirrorlist via env var
+
+Use `MIRRORLIST_SERVERS_X86_64` with semicolon-separated mirror URLs:
+
+```yaml
+services:
+  aurcache:
+    image: ghcr.io/lukas-heiligenbrunner/aurcache:latest
+    environment:
+      - MIRRORLIST_SERVERS_X86_64=https://mirror.rackspace.com/archlinux/$$repo/os/$$arch;https://mirrors.kernel.org/archlinux/$$repo/os/$$arch
+    # ... rest of config
+```
+
+When this env var is set, automatic mirror ranking is disabled.
+
+## Manually set mirrorlist via file mount
 
 To enable auto mirror ranking set `MIRROR_RANK_SCHEDULE` to your desired cron schedule and it will automatically rerank the mirrors based on their download speed.
 


### PR DESCRIPTION
This adds a new way to specify the mirrorlist: through an env var that contains a list of servers (semicolon-separated).

This makes it easier to fully configure AURCache through the docker-compose file. Until now, using a custom mirrorlist required a file on the host and mounting it in the aurcache container, which spread the config in several places.

I realize there's no super clean way to specify the content of the mirrorlist through env vars (which is maybe why it wasn't possible at all so far). I had a few options:
* Directly specify the content. Gross with multiple `=` signs and escaped newlines.
* Specify the content as base64. Solves the aesthetic by making it a black box and a pain to edit.
* Use a different way to specify the list of servers:
  * Colon-separated servers, like $PATH? Not a good idea with `scheme://` and `:port`.
  * JSON-encoded or similar? Maybe?
  * Semi-colon-separated: the current solution. Comma-separated would be an option as well.
  * Only support a single server. That probably covers many cases of a local repo, but feels like an arbitrary limitation.