### PR TITLE
use system locale to display dates and times correct

### DIFF
--- a/frontend/lib/components/activity_table.dart
+++ b/frontend/lib/components/activity_table.dart
@@ -1,6 +1,7 @@
 import 'package:aurcache/models/activity.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import '../constants/color_constants.dart';
 
 class ActivityTable extends ConsumerWidget {
@@ -35,15 +36,7 @@ class ActivityTable extends ConsumerWidget {
   DataRow buildDataRow(Activity activity, BuildContext context, WidgetRef ref) {
     return DataRow(
       cells: [
-        DataCell(
-          Text(
-            '${activity.timestamp.day.toString().padLeft(2, '0')}.'
-            '${activity.timestamp.month.toString().padLeft(2, '0')}.'
-            '${activity.timestamp.year.toString()} '
-            '${activity.timestamp.hour.toString().padLeft(2, '0')}:'
-            '${activity.timestamp.minute.toString().padLeft(2, '0')}',
-          ),
-        ),
+        DataCell(Text(DateFormat.yMd().add_Hm().format(activity.timestamp))),
         DataCell(Text(activity.user ?? "You")),
         DataCell(Text(activity.text)),
       ],

--- a/frontend/lib/components/builds_table.dart
+++ b/frontend/lib/components/builds_table.dart
@@ -1,6 +1,7 @@
 import 'package:aurcache/utils/responsive.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 
 import '../constants/color_constants.dart';
@@ -43,11 +44,7 @@ class BuildsTable extends StatelessWidget {
       cells: [
         if (context.desktop) DataCell(Text(build.id.toString())),
         if (context.desktop)
-          DataCell(
-            Text(
-              '${build.start_time.day.toString().padLeft(2, '0')}.${build.start_time.month.toString().padLeft(2, '0')}.${build.start_time.year.toString()}',
-            ),
-          ),
+          DataCell(Text(DateFormat.yMd().format(build.start_time))),
         DataCell(
           Text(build.pkg_name),
           onTap: context.mobile

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -5,10 +5,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:toastification/toastification.dart';
 import 'constants/color_constants.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
   if (kIsWeb) {
     if (bool.fromEnvironment('dart.tool.dart2wasm')) {
       print("You are using the WASM build of Flutter");
@@ -18,6 +22,12 @@ void main() {
       );
     }
   }
+
+  // Pick up the browser/system locale so date/number formattings are right
+  final platformLocale = WidgetsBinding.instance.platformDispatcher.locale
+      .toLanguageTag();
+  await initializeDateFormatting(platformLocale, null);
+  Intl.defaultLocale = platformLocale;
 
   GoRouter.optionURLReflectsImperativeAPIs = true;
   runApp(

--- a/frontend/lib/screens/package_screen.dart
+++ b/frontend/lib/screens/package_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_tags_x/flutter_tags_x.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:skeletonizer/skeletonizer.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -200,13 +201,11 @@ class _PackageScreenState extends ConsumerState<PackageScreen> {
                 return [
                   _sideCard(
                     title: "Last Updated",
-                    subtitle:
-                        "${lastUpdated.year}-${lastUpdated.month.toString().padLeft(2, '0')}-${lastUpdated.day.toString().padLeft(2, '0')}",
+                    subtitle: DateFormat.yMd().format(lastUpdated),
                   ),
                   _sideCard(
                     title: "First submitted",
-                    subtitle:
-                        "${firstSubmitted.year}-${firstSubmitted.month.toString().padLeft(2, '0')}-${firstSubmitted.day.toString().padLeft(2, '0')}",
+                    subtitle: DateFormat.yMd().format(firstSubmitted),
                   ),
                   _sideCard(title: "Licenses", subtitle: aur.licenses ?? "-"),
                   _sideCard(

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -431,7 +431,7 @@ packages:
     source: hosted
     version: "4.1.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   json_annotation: 4.11.0
   freezed_annotation: 3.1.0
   step_progress: 2.7.1
+  intl: ^0.20.2
   flutter_settings_ui:
     # path: ../../flutter_settings_ui  # local dev
     git:


### PR DESCRIPTION
I live in Austria, thats my local date format.
This PR changes it to be system setting agnostic.
this changes date formattings in: 
* build start_time column; 
* "Last Updated" / "First submitted" cards
* activity timestamp column

(still needs testing in real browser)

I think adding a settings entry for this is a bit overkill and not really necessary, right?

fix #356
