### PR TITLE
[fix(builder): pre-import PKGBUILD validpgpkeys before build

### DIFF
--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -239,7 +239,8 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
         let build_cmd = match source_data {
             SourceData::Aur { .. } => {
                 // -Ga forces paru to clone from AUR even when a same-named package exists in a repo
-                let import_keys = import_pgp_keys(&format!("{}/{name}", container_build_dir.display()));
+                let import_keys =
+                    import_pgp_keys(&format!("{}/{name}", container_build_dir.display()));
                 format!(
                     "mkdir -p {container_build_dir} && cd {container_build_dir} && {self_update} && paru -Ga {name} && {import_keys} && paru {build_flags} *",
                     container_build_dir = container_build_dir.display(),

--- a/backend/aurcache-builder/src/docker.rs
+++ b/backend/aurcache-builder/src/docker.rs
@@ -227,18 +227,28 @@ and check also if the 'DOCKER_HOST=unix:///var/run/user/1000/podman/podman.sock'
         }
 
         let self_update = "paru -Syu --noconfirm --noprogressbar --color never";
+        // Import PGP keys listed in validpgpkeys from PKGBUILD before building.
+        // Tries multiple keyservers as fallback; never fails the build if import fails
+        // (--pgpfetch will still attempt to fetch during build as a secondary attempt).
+        let import_pgp_keys = |pkgbuild_dir: &str| {
+            format!(
+                r#"(bash -c 'cd {pkgbuild_dir} && source PKGBUILD 2>/dev/null; for k in "${{validpgpkeys[@]:-}}"; do [ -z "$k" ] && continue; gpg --keyserver hkps://keyserver.ubuntu.com --recv-keys "$k" 2>/dev/null || gpg --keyserver hkps://keys.openpgp.org --recv-keys "$k" 2>/dev/null || gpg --keyserver hkp://pgp.mit.edu --recv-keys "$k" 2>/dev/null || echo "Warning: failed to import PGP key $k"; done' || true)"#
+            )
+        };
         let source_data = SourceData::from_str(self.package_model.source_data.get()?)?;
         let build_cmd = match source_data {
             SourceData::Aur { .. } => {
                 // -Ga forces paru to clone from AUR even when a same-named package exists in a repo
+                let import_keys = import_pgp_keys(&format!("{}/{name}", container_build_dir.display()));
                 format!(
-                    "mkdir -p {container_build_dir} && cd {container_build_dir} && {self_update} && paru -Ga {name} && paru {build_flags} *",
+                    "mkdir -p {container_build_dir} && cd {container_build_dir} && {self_update} && paru -Ga {name} && {import_keys} && paru {build_flags} *",
                     container_build_dir = container_build_dir.display(),
                 )
             }
             SourceData::Git { .. } => {
+                let import_keys = import_pgp_keys(GIT_REPO_PATH);
                 format!(
-                    "sudo chmod -R 1777 {GIT_REPO_PATH} && {self_update} && cd {GIT_REPO_PATH} && paru {build_flags} ."
+                    "sudo chmod -R 1777 {GIT_REPO_PATH} && {self_update} && cd {GIT_REPO_PATH} && {import_keys} && paru {build_flags} ."
                 )
             }
             SourceData::Upload { .. } => {


### PR DESCRIPTION
Keyserver connectivity inside Docker containers causes --pgpfetch to silently fail for packages with validpgpkeys (e.g. zfs-utils key 6AD860EED4598027), breaking source verification.

Sources PKGBUILD after paru -Ga to extract validpgpkeys, then tries three keyservers (Ubuntu → OpenPGP → MIT) before paru runs. Never fails the build; --pgpfetch remains as secondary fallback.

Partially closes #64 (Manual import is not handeld)